### PR TITLE
Add MailHog and WP-CLI to Test Drive

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hello-login",
-  "version": "1.0.0",
+  "version": "1.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3153,14 +3153,6 @@
         "webpack-bundle-analyzer": "^4.4.2",
         "webpack-cli": "^4.9.1",
         "webpack-dev-server": "^4.4.0"
-      },
-      "dependencies": {
-        "prettier": {
-          "version": "npm:wp-prettier@2.2.1-beta-1",
-          "resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.2.1-beta-1.tgz",
-          "integrity": "sha512-+JHkqs9LC/JPp51yy1hzs3lQ7qeuWCwOcSzpQNeeY/G7oSpnF61vxt7hRh87zNRTr6ob2ndy0W8rVzhgrcA+Gw==",
-          "dev": true
-        }
       }
     },
     "@wordpress/stylelint-config": {
@@ -15497,6 +15489,12 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true
+    },
+    "prettier": {
+      "version": "npm:wp-prettier@2.2.1-beta-1",
+      "resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.2.1-beta-1.tgz",
+      "integrity": "sha512-+JHkqs9LC/JPp51yy1hzs3lQ7qeuWCwOcSzpQNeeY/G7oSpnF61vxt7hRh87zNRTr6ob2ndy0W8rVzhgrcA+Gw==",
       "dev": true
     },
     "prettier-linter-helpers": {

--- a/test-drive/README.md
+++ b/test-drive/README.md
@@ -1,6 +1,22 @@
 # Test Drive
 
-## Bash Session Inside a Container
+## Local Testing
+
+Use `docker compose` (or the older `docker-compose`) to run the containers required for local testing. The `up.sh` and
+`down.sh` are simple wrappers around `docker compose` commands that also open a browser and prune volumes.
+
+Once the continers are running use the following URLs:
+* http://localhost:8080/ - WordPress instance
+* http://localhost:8025/ - MailHog web interface
+
+Once the WordPress instance has basic configuration and an admin account you can install the latest released Hellō Login
+plugin from the WordPress plugin repo.
+
+You can run the `install.sh` script to copy local plugin files into the docker container.
+
+## Docker Cheat Sheet
+
+### Bash Session Inside a Container
 
 Start a bash session inside the WordPress container:
 ```shell
@@ -10,14 +26,14 @@ docker exec -it test-drive-hello_wordpress-1 bash
 * WordPress root folder: `/var/www/html/`
 * plugin folder: `/var/www/html/wp-content/plugins/`
 
-# Copy Out of a Container
+### Copy Out of a Container
 
 Copy a plugin out of the WordPress directory:
 ```shell
 docker cp test-drive-hello_wordpress-1:/var/www/html/wp-content/plugins/akismet ./
 ```
 
-# Copy Into a Container
+### Copy Into a Container
 
 Make the target directory:
 ```shell

--- a/test-drive/README.md
+++ b/test-drive/README.md
@@ -14,6 +14,15 @@ plugin from the WordPress plugin repo.
 
 You can run the `install.sh` script to copy local plugin files into the docker container.
 
+## WordPress CLI
+
+Use the wp-cli.sh script to run [WordPress CLI](https://wp-cli.org/) commands.
+
+Example:
+```shell
+./wp-cli.sh user list
+```
+
 ## Docker Cheat Sheet
 
 ### Bash Session Inside a Container

--- a/test-drive/docker-compose.yaml
+++ b/test-drive/docker-compose.yaml
@@ -1,4 +1,4 @@
-version: '3.1'
+version: '3.7'
 
 services:
 
@@ -7,6 +7,7 @@ services:
     restart: always
     depends_on:
       - hello_db
+      - hello_mailhog
     ports:
       - 8080:80
     environment:
@@ -14,6 +15,8 @@ services:
       WORDPRESS_DB_USER: exampleuser
       WORDPRESS_DB_PASSWORD: examplepass
       WORDPRESS_DB_NAME: exampledb
+      SMTP_HOST: hello_mailhog
+      SMTP_PORT: 1025
 
   hello_db:
     image: mysql:5.7
@@ -23,3 +26,10 @@ services:
       MYSQL_USER: exampleuser
       MYSQL_PASSWORD: examplepass
       MYSQL_RANDOM_ROOT_PASSWORD: '1'
+
+  hello_mailhog:
+    image: mailhog/mailhog
+    restart: always
+    ports:
+      - 8025:8025 # web interface
+      - 1025:1025 # SMTP

--- a/test-drive/wp-cli.sh
+++ b/test-drive/wp-cli.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+docker run -it --rm \
+--volumes-from test-drive-hello_wordpress-1 \
+--network container:test-drive-hello_wordpress-1 \
+-e WORDPRESS_DB_USER=exampleuser \
+-e WORDPRESS_DB_PASSWORD=examplepass \
+-e WORDPRESS_DB_NAME=exampledb \
+-e WORDPRESS_DB_HOST=hello_db \
+wordpress:cli "$@"


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [plugin Contributing guideline](https://github.com/oidc-wp/openid-connect-generi/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

* MailHog container added to docker compose, accessible at http://localhost:8025/
* WP-CLI helper script added
