### PR TITLE
fix plugin settings and login page redirects after connecting with Hellō

### DIFF
--- a/includes/hello-login-client-wrapper.php
+++ b/includes/hello-login-client-wrapper.php
@@ -174,13 +174,17 @@ class Hello_Login_Client_Wrapper {
 			return '';
 		}
 
+		// If using the login form, default redirect to the home page
+		if ( isset( $GLOBALS['pagenow'] ) && 'wp-login.php' == $GLOBALS['pagenow'] ) {
+			return home_url();
+		}
+
+		if ( is_admin() ) {
+			return admin_url(sprintf(basename($_SERVER['REQUEST_URI'])));
+		}
+
 		// Default redirect to the homepage.
 		$redirect_url = home_url();
-
-		// If using the login form, default redirect to the admin dashboard.
-		if ( isset( $GLOBALS['pagenow'] ) && 'wp-login.php' == $GLOBALS['pagenow'] ) {
-			$redirect_url = admin_url();
-		}
 
 		// Honor Core WordPress & other plugin redirects.
 		if ( isset( $_REQUEST['redirect_to'] ) ) {

--- a/test-drive/README.md
+++ b/test-drive/README.md
@@ -16,7 +16,8 @@ You can run the `install.sh` script to copy local plugin files into the docker c
 
 ## WordPress CLI
 
-Use the wp-cli.sh script to run [WordPress CLI](https://wp-cli.org/) commands.
+Use the wp-cli.sh script to run [WordPress CLI](https://wp-cli.org/) commands. Command reference at
+https://developer.wordpress.org/cli/commands/
 
 ### Examples ###
 List users:

--- a/test-drive/README.md
+++ b/test-drive/README.md
@@ -5,7 +5,7 @@
 Use `docker compose` (or the older `docker-compose`) to run the containers required for local testing. The `up.sh` and
 `down.sh` are simple wrappers around `docker compose` commands that also open a browser and prune volumes.
 
-Once the continers are running use the following URLs:
+Once the containers are running use the following URLs:
 * http://localhost:8080/ - WordPress instance
 * http://localhost:8025/ - MailHog web interface
 
@@ -18,9 +18,15 @@ You can run the `install.sh` script to copy local plugin files into the docker c
 
 Use the wp-cli.sh script to run [WordPress CLI](https://wp-cli.org/) commands.
 
-Example:
+### Examples ###
+List users:
 ```shell
 ./wp-cli.sh user list
+```
+
+Unlink user 1 from Hellō:
+```shell
+./wp-cli.sh user meta delete 1 hello-login-subject-identity
 ```
 
 ## Docker Cheat Sheet


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [plugin Contributing guideline](https://github.com/oidc-wp/openid-connect-generi/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

* after linking admin account from plugin settings page the admin is returned back to same plugin settings page
* after user connects with Hellō from `wp-login.php` page the user is sent to home URL
* added example and reference link for WP CLI

Closes #15 .
