### PR TITLE
authentication request URL generated through REST API on button click

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -10,6 +10,7 @@
 
 function hello_login_enqueue_scripts_and_styles() {
 	wp_enqueue_script( 'hello-button', 'https://cdn.hello.coop/js/hello-btn.js' );
+	wp_enqueue_script( 'auth-url', plugin_dir_url( __DIR__ ) . 'js/auth_url.js' );
 	wp_enqueue_style( 'hello-button', 'https://cdn.hello.coop/css/hello-btn.css' );
 }
 

--- a/includes/hello-login-client-wrapper.php
+++ b/includes/hello-login-client-wrapper.php
@@ -141,7 +141,55 @@ class Hello_Login_Client_Wrapper {
 			add_filter( 'hello-login-alter-request', array( $client_wrapper, 'alter_authentication_token_request' ), 15, 3 );
 		}
 
+		add_action( 'rest_api_init', array( $client_wrapper, 'register_rest_routes' ) );
+
 		return $client_wrapper;
+	}
+
+	/**
+	 * Register REST API routes.
+	 *
+	 * @return void
+	 */
+	public function register_rest_routes() {
+		register_rest_route(
+			'hello-login/v1',
+			'/auth_url/',
+			array(
+				'methods' => 'GET',
+				'callback' => array( $this, 'rest_auth_url' ),
+				'permission_callback' => function() { return ''; },
+			)
+		);
+	}
+
+	/**
+	 * Get the authentication URL for the REST API.
+	 *
+	 * @param WP_REST_Request $request The REST request object.
+	 * @return string|null|WP_Error A Hello service authentication URL.
+	 */
+	public function rest_auth_url( WP_REST_Request $request ) {
+		$atts = array();
+
+		if ( $request->has_param( 'redirect_to_path' ) ) {
+			$redirect_to_path = $request->get_param( 'redirect_to_path' );
+
+			// Validate that only a path was passed in.
+			$p = parse_url( $redirect_to_path );
+
+			if ( isset( $p['scheme'] ) || isset( $p['host'] ) || isset( $p['port'] ) || isset( $p['user'] ) || isset( $p['pass'] ) ) {
+				return new WP_Error( 'invalid_path', 'Invalid redirect_to_path', array( 'status' => 400 ) );
+			}
+
+			$redirect_to_path = '/' . ltrim( $redirect_to_path, '/' );
+			$redirect_to = rtrim( home_url(), '/' ) . $redirect_to_path;
+			$atts = array(
+				'redirect_to' => $redirect_to,
+			);
+		}
+
+		return $this->get_authentication_url( $atts );
 	}
 
 	/**

--- a/includes/hello-login-client-wrapper.php
+++ b/includes/hello-login-client-wrapper.php
@@ -167,7 +167,7 @@ class Hello_Login_Client_Wrapper {
 	 * Get the authentication URL for the REST API.
 	 *
 	 * @param WP_REST_Request $request The REST request object.
-	 * @return string|null|WP_Error A Hello service authentication URL.
+	 * @return array|WP_Error A Hello service authentication URL.
 	 */
 	public function rest_auth_url( WP_REST_Request $request ) {
 		$atts = array();
@@ -189,7 +189,9 @@ class Hello_Login_Client_Wrapper {
 			);
 		}
 
-		return $this->get_authentication_url( $atts );
+		return array(
+			'url' =>$this->get_authentication_url( $atts ),
+		);
 	}
 
 	/**

--- a/includes/hello-login-client-wrapper.php
+++ b/includes/hello-login-client-wrapper.php
@@ -284,10 +284,6 @@ class Hello_Login_Client_Wrapper {
 		// Validate the redirect to value to prevent a redirection attack.
 		if ( ! empty( $atts['redirect_to'] ) ) {
 			$atts['redirect_to'] = wp_validate_redirect( $atts['redirect_to'], home_url() );
-
-			if ( str_contains( $atts['redirect_to'], "login" ) ) {
-				$atts['redirect_to'] = home_url();
-			}
 		}
 
 		$separator = '?';

--- a/includes/hello-login-client-wrapper.php
+++ b/includes/hello-login-client-wrapper.php
@@ -284,6 +284,10 @@ class Hello_Login_Client_Wrapper {
 		// Validate the redirect to value to prevent a redirection attack.
 		if ( ! empty( $atts['redirect_to'] ) ) {
 			$atts['redirect_to'] = wp_validate_redirect( $atts['redirect_to'], home_url() );
+
+			if ( str_contains( $atts['redirect_to'], "login" ) ) {
+				$atts['redirect_to'] = home_url();
+			}
 		}
 
 		$separator = '?';

--- a/includes/hello-login-login-form.php
+++ b/includes/hello-login-login-form.php
@@ -103,7 +103,11 @@ class Hello_Login_Login_Form {
 
 		if ( ! empty( $this->settings->client_id ) ) {
 			// Login button is appended to existing messages in case of error.
-			$message .= $this->make_login_button();
+			$atts = array(
+				'redirect_to' => home_url(),
+			);
+
+			$message .= $this->make_login_button($atts);
 
 			// Login form toggle is appended right after the button
 			$message .= $this->make_login_form_toggle();
@@ -141,11 +145,17 @@ class Hello_Login_Login_Form {
 	 * @return string
 	 */
 	public function make_login_button( $atts = array() ) {
-		// TODO $atts are not passed down to get_authentication_url
+		$redirect_to_path = '';
+
+		if ( isset( $atts['redirect_to'] ) ) {
+			$p = parse_url( $atts['redirect_to'] );
+			$redirect_to_path = $p['path'] . '?' . $p['query'];
+		}
+
 		ob_start();
 		?>
 		<div class="hello-container" style="display: block; text-align: center;">
-			<button class="hello-btn" onclick="navigateToHelloAuthRequestUrl()">
+			<button class="hello-btn" onclick="navigateToHelloAuthRequestUrl('<?php print esc_js( $redirect_to_path ); ?>')">
 				<?php print esc_html__( 'ō   Continue with Hellō', 'hello-login' ); ?>
 			</button>
 			<button class="hello-about"></button>

--- a/includes/hello-login-login-form.php
+++ b/includes/hello-login-login-form.php
@@ -149,7 +149,12 @@ class Hello_Login_Login_Form {
 
 		if ( isset( $atts['redirect_to'] ) ) {
 			$p = parse_url( $atts['redirect_to'] );
-			$redirect_to_path = $p['path'] . '?' . $p['query'];
+
+			$redirect_to_path = empty( $p['path'] ) ? '/' : $p['path'];
+
+			if ( ! empty( $p['query'] ) ) {
+				$redirect_to_path .= '?' . $p['query'];
+			}
 		}
 
 		ob_start();

--- a/includes/hello-login-login-form.php
+++ b/includes/hello-login-login-form.php
@@ -141,22 +141,13 @@ class Hello_Login_Login_Form {
 	 * @return string
 	 */
 	public function make_login_button( $atts = array() ) {
-
-		$atts = shortcode_atts(
-				array(
-						'button_text' => __( 'ō   Continue with Hellō', 'hello-login' ),
-				),
-				$atts,
-				'hello_login_button'
-		);
-
-		$href = $this->client_wrapper->get_authentication_url( $atts );
-		$href = esc_url_raw( $href );
-
+		// TODO $atts are not passed down to get_authentication_url
 		ob_start();
 		?>
 		<div class="hello-container" style="display: block; text-align: center;">
-			<button class="hello-btn" onclick="window.location.href = '<?php print esc_attr( $href ); ?>'"></button>
+			<button class="hello-btn" onclick="navigateToHelloAuthRequestUrl()">
+				<?php print esc_html__( 'ō   Continue with Hellō', 'hello-login' ); ?>
+			</button>
 			<button class="hello-about"></button>
 		</div>
 		<?php

--- a/includes/hello-login-settings-page.php
+++ b/includes/hello-login-settings-page.php
@@ -510,7 +510,7 @@ class Hello_Login_Settings_Page {
 
 			<?php if ( empty( get_user_meta( get_current_user_id(), 'hello-login-subject-identity', true ) ) ) { ?>
 				<p id="link-hello-wallet">You are logged in with a username and a password. Link your Hellō Wallet to use Hellō in the future.</p>
-				<button class="hello-btn" data-label="ō&nbsp;&nbsp;&nbsp;Link Hellō" onclick="navigateToHelloAuthRequestUrl()"></button>
+				<button class="hello-btn" data-label="ō&nbsp;&nbsp;&nbsp;Link Hellō" onclick="navigateToHelloAuthRequestUrl('')"></button>
 			<?php } ?>
 
 			<p>Use the <a href="https://console.hello.coop/" target="_blank">Hellō Console</a> to update your Hellō configuration</p>

--- a/includes/hello-login-settings-page.php
+++ b/includes/hello-login-settings-page.php
@@ -487,10 +487,6 @@ class Hello_Login_Settings_Page {
 			$custom_logo_data = wp_get_attachment_image_src( $custom_logo_id , 'full' );
 			$custom_logo_url = $custom_logo_data[0];
 		}
-
-		$href = $this->client_wrapper->get_authentication_url();
-		$href = esc_url_raw( $href );
-
 		?>
 		<div class="wrap">
 			<h2><?php print esc_html( get_admin_page_title() ); ?></h2>
@@ -514,7 +510,7 @@ class Hello_Login_Settings_Page {
 
 			<?php if ( empty( get_user_meta( get_current_user_id(), 'hello-login-subject-identity', true ) ) ) { ?>
 				<p id="link-hello-wallet">You are logged in with a username and a password. Link your Hellō Wallet to use Hellō in the future.</p>
-				<button class="hello-btn" data-label="ō&nbsp;&nbsp;&nbsp;Link Hellō" onclick="window.location.href = '<?php print esc_attr( $href ); ?>'"></button>
+				<button class="hello-btn" data-label="ō&nbsp;&nbsp;&nbsp;Link Hellō" onclick="navigateToHelloAuthRequestUrl()"></button>
 			<?php } ?>
 
 			<p>Use the <a href="https://console.hello.coop/" target="_blank">Hellō Console</a> to update your Hellō configuration</p>

--- a/js/auth_url.js
+++ b/js/auth_url.js
@@ -1,6 +1,6 @@
 async function navigateToHelloAuthRequestUrl() {
 	try {
-		const res = await fetch('/wp-json/hello-login/v1/auth_url?redirect_to_path=%2F')
+		const res = await fetch('/wp-json/hello-login/v1/auth_url?redirect_to_path=' + encodeURIComponent(location.pathname+location.search))
 		const json = await res.json()
 		window.location.href = json['url']
 	} catch (err) {

--- a/js/auth_url.js
+++ b/js/auth_url.js
@@ -1,6 +1,10 @@
-async function navigateToHelloAuthRequestUrl() {
+async function navigateToHelloAuthRequestUrl(redirect_to_path) {
 	try {
-		const res = await fetch('/wp-json/hello-login/v1/auth_url?redirect_to_path=' + encodeURIComponent(location.pathname+location.search))
+		if (!redirect_to_path) {
+			redirect_to_path = location.pathname + location.search;
+		}
+
+		const res = await fetch('/wp-json/hello-login/v1/auth_url?redirect_to_path=' + encodeURIComponent(redirect_to_path))
 		const json = await res.json()
 		window.location.href = json['url']
 	} catch (err) {

--- a/js/auth_url.js
+++ b/js/auth_url.js
@@ -1,6 +1,6 @@
 async function navigateToHelloAuthRequestUrl() {
 	try {
-		const res = await fetch('/wp-json/hello-login/v1/auth_url')
+		const res = await fetch('/wp-json/hello-login/v1/auth_url?redirect_to_path=%2F')
 		const json = await res.json()
 		window.location.href = json['url']
 	} catch (err) {

--- a/js/auth_url.js
+++ b/js/auth_url.js
@@ -1,0 +1,9 @@
+async function navigateToHelloAuthRequestUrl() {
+	try {
+		const res = await fetch('/wp-json/hello-login/v1/auth_url')
+		const json = await res.json()
+		window.location.href = json['url']
+	} catch (err) {
+		console.error(err)
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [plugin Contributing guideline](https://github.com/oidc-wp/openid-connect-generi/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
* authentication request URL generated through REST API on button click
* `redirect_to` url determined based on context, when button is generated
* first use of the `hello-login/v1` namespace for REST APIs

Closes #29 .
