### PR TITLE
use REST API URL for redirect URI

### DIFF
--- a/hello-login.php
+++ b/hello-login.php
@@ -151,10 +151,6 @@ class Hello_Login {
 
 		$redirect_uri = rest_url( 'hello-login/v1/callback' );
 
-		if ( $this->settings->alternate_redirect_uri ) {
-			$redirect_uri = site_url( '/hello-login-callback' );
-		}
-
 		$state_time_limit = 180;
 		if ( $this->settings->state_time_limit ) {
 			$state_time_limit = intval( $this->settings->state_time_limit );
@@ -377,7 +373,6 @@ class Hello_Login {
 
 				// Plugin settings.
 				'enforce_privacy' => defined( 'OIDC_ENFORCE_PRIVACY' ) ? intval( OIDC_ENFORCE_PRIVACY ) : 0,
-				'alternate_redirect_uri' => 0,
 				'token_refresh_enable' => 0,
 				'link_existing_users' => defined( 'OIDC_LINK_EXISTING_USERS' ) ? intval( OIDC_LINK_EXISTING_USERS ) : 1,
 				'create_if_does_not_exist' => defined( 'OIDC_CREATE_IF_DOES_NOT_EXIST' ) ? intval( OIDC_CREATE_IF_DOES_NOT_EXIST ) : 1,

--- a/hello-login.php
+++ b/hello-login.php
@@ -149,7 +149,7 @@ class Hello_Login {
 	 */
 	public function init() {
 
-		$redirect_uri = admin_url( 'admin-ajax.php?action=hello-login-callback' );
+		$redirect_uri = rest_url( 'hello-login/v1/callback' );
 
 		if ( $this->settings->alternate_redirect_uri ) {
 			$redirect_uri = site_url( '/hello-login-callback' );

--- a/includes/hello-login-client-wrapper.php
+++ b/includes/hello-login-client-wrapper.php
@@ -161,6 +161,15 @@ class Hello_Login_Client_Wrapper {
 				'permission_callback' => function() { return ''; },
 			)
 		);
+		register_rest_route(
+			'hello-login/v1',
+			'/callback/',
+			array(
+				'methods' => 'GET',
+				'callback' => array( $this, '' ),
+				'permission_callback' => function() { return 'authentication_request_callback'; },
+			)
+		);
 	}
 
 	/**

--- a/includes/hello-login-client-wrapper.php
+++ b/includes/hello-login-client-wrapper.php
@@ -117,6 +117,8 @@ class Hello_Login_Client_Wrapper {
 
 		if ( is_admin() ) {
 			/*
+			 * WARNING: for backwards compatibility only.
+			 *
 			 * Use the ajax url to handle processing authorization without any html output
 			 * this callback will occur when then IDP returns with an authenticated value
 			 */

--- a/includes/hello-login-client-wrapper.php
+++ b/includes/hello-login-client-wrapper.php
@@ -126,13 +126,6 @@ class Hello_Login_Client_Wrapper {
 			add_action( 'wp_ajax_nopriv_hello-login-callback', array( $client_wrapper, 'authentication_request_callback' ) );
 		}
 
-		if ( $settings->alternate_redirect_uri ) {
-			// Provide an alternate route for authentication_request_callback.
-			add_rewrite_rule( '^hello-login-callback/?', 'index.php?hello-login-callback=1', 'top' );
-			add_rewrite_tag( '%hello-login-callback%', '1' );
-			add_action( 'parse_request', array( $client_wrapper, 'alternate_redirect_uri_parse_request' ) );
-		}
-
 		// Verify token for any logged in user.
 		if ( is_user_logged_in() ) {
 			add_action( 'wp_loaded', array( $client_wrapper, 'ensure_tokens_still_fresh' ) );
@@ -203,23 +196,6 @@ class Hello_Login_Client_Wrapper {
 		return array(
 			'url' =>$this->get_authentication_url( $atts ),
 		);
-	}
-
-	/**
-	 * Implements WordPress parse_request action.
-	 *
-	 * @param WP_Query $query The WordPress query object.
-	 *
-	 * @return mixed
-	 */
-	public function alternate_redirect_uri_parse_request( $query ) {
-		if ( isset( $query->query_vars['hello-login-callback'] ) &&
-			 '1' === $query->query_vars['hello-login-callback'] ) {
-			$this->authentication_request_callback();
-			exit;
-		}
-
-		return $query;
 	}
 
 	/**

--- a/includes/hello-login-option-settings.php
+++ b/includes/hello-login-option-settings.php
@@ -50,7 +50,6 @@
  * Plugin Settings:
  *
  * @property bool $enforce_privacy          The flag to indicates whether a user us required to be authenticated to access the site.
- * @property bool $alternate_redirect_uri   The flag to indicate whether to use the alternative redirect URI.
  * @property bool $token_refresh_enable     The flag whether to support refresh tokens by IDPs.
  * @property bool $link_existing_users      The flag to indicate whether to link to existing WordPress-only accounts or greturn an error.
  * @property bool $create_if_does_not_exist The flag to indicate whether to create new users or not.

--- a/includes/hello-login-settings-page.php
+++ b/includes/hello-login-settings-page.php
@@ -475,10 +475,6 @@ class Hello_Login_Settings_Page {
 		$redirect_uri = rest_url( 'hello-login/v1/callback' );
 		$plugin_settings_uri = admin_url( '/options-general.php?page=hello-login-settings' );
 
-		if ( $this->settings->alternate_redirect_uri ) {
-			$redirect_uri = site_url( '/hello-login-callback' );
-		}
-
 		$show_succeeded = false;
 		if ( isset( $_GET['client_id'] ) && empty( $this->settings->client_id ) ) {
 			$this->settings->client_id = sanitize_text_field( $_GET['client_id'] );

--- a/includes/hello-login-settings-page.php
+++ b/includes/hello-login-settings-page.php
@@ -472,7 +472,7 @@ class Hello_Login_Settings_Page {
 	public function settings_page() {
 		wp_enqueue_style( 'hello-login-admin', plugin_dir_url( __DIR__ ) . 'css/styles-admin.css', array(), Hello_Login::VERSION, 'all' );
 
-		$redirect_uri = admin_url( 'admin-ajax.php?action=hello-login-callback' );
+		$redirect_uri = rest_url( 'hello-login/v1/callback' );
 		$plugin_settings_uri = admin_url( '/options-general.php?page=hello-login-settings' );
 
 		if ( $this->settings->alternate_redirect_uri ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [plugin Contributing guideline](https://github.com/oidc-wp/openid-connect-generi/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

* redirect URI is being changed to a path only REST API URL: `/wp-json/hello-login/v1/callback`
* breaking change, clients already configured with previous `/wp-admin/admin-ajax.php?action=hello-login-callback` redirect URI will have to manually add the new URI in [Hellō Console](https://console.hello.coop/)
* previous redirect URI handler still in place, will be removed by a future PR
* removed the `alternate_redirect_uri` setting and associated code

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Related issue: #40 .
