### PR TITLE
add REST API for Quickstart response

### DIFF
--- a/includes/hello-login-client-wrapper.php
+++ b/includes/hello-login-client-wrapper.php
@@ -161,8 +161,8 @@ class Hello_Login_Client_Wrapper {
 			'/callback/',
 			array(
 				'methods' => 'GET',
-				'callback' => array( $this, '' ),
-				'permission_callback' => function() { return 'authentication_request_callback'; },
+				'callback' => array( $this, 'authentication_request_callback' ),
+				'permission_callback' => function() { return ''; },
 			)
 		);
 		register_rest_route(

--- a/includes/hello-login-client-wrapper.php
+++ b/includes/hello-login-client-wrapper.php
@@ -165,6 +165,15 @@ class Hello_Login_Client_Wrapper {
 				'permission_callback' => function() { return 'authentication_request_callback'; },
 			)
 		);
+		register_rest_route(
+			'hello-login/v1',
+			'/quickstart/',
+			array(
+				'methods' => 'GET',
+				'callback' => array( $this, 'quickstart_callback' ),
+				'permission_callback' => function() { return ''; },
+			)
+		);
 	}
 
 	/**
@@ -196,6 +205,24 @@ class Hello_Login_Client_Wrapper {
 		return array(
 			'url' =>$this->get_authentication_url( $atts ),
 		);
+	}
+
+	/**
+	 * Process the Quickstart response.
+	 *
+	 * @param WP_REST_Request $request The REST request object.
+	 * @return WP_Error A Quickstart response processing error.
+	 */
+	public function quickstart_callback( WP_REST_Request $request ) {
+		$atts = array();
+
+		if ( $request->has_param( 'client_id' ) ) {
+			$client_id = $request->get_param( 'client_id' );
+
+			exit();
+		} else {
+			return new WP_Error( 'invalid_client_id', 'Missing or invalid client id', array( 'status' => 400 ) );
+		}
 	}
 
 	/**

--- a/includes/hello-login-client-wrapper.php
+++ b/includes/hello-login-client-wrapper.php
@@ -214,16 +214,16 @@ class Hello_Login_Client_Wrapper {
 	 * @return WP_Error A Quickstart response processing error.
 	 */
 	public function rest_quickstart_callback( WP_REST_Request $request ) {
-		$atts = array();
-
 		if ( $request->has_param( 'client_id' ) ) {
+			$client_id = sanitize_text_field( $request->get_param( 'client_id' ) );
+
+			if ( preg_match('/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/', $client_id) !== 1 ) {
+				return new WP_Error( 'invalid_client_id', 'Invalid client id', array( 'status' => 400 ) );
+			}
+
 			if ( ! empty( $this->settings->client_id ) ) {
 				return new WP_Error( 'existing_client_id', 'Client id already set', array( 'status' => 403 ) );
 			}
-
-			$client_id = sanitize_text_field( $request->get_param( 'client_id' ) );
-
-			// TODO validate the client id format, must be UUIDv4.
 
 			$this->settings->client_id = $client_id;
 			$this->settings->save();

--- a/includes/hello-login-settings-page.php
+++ b/includes/hello-login-settings-page.php
@@ -473,15 +473,7 @@ class Hello_Login_Settings_Page {
 		wp_enqueue_style( 'hello-login-admin', plugin_dir_url( __DIR__ ) . 'css/styles-admin.css', array(), Hello_Login::VERSION, 'all' );
 
 		$redirect_uri = rest_url( 'hello-login/v1/callback' );
-		$plugin_settings_uri = admin_url( '/options-general.php?page=hello-login-settings' );
-
-		$show_succeeded = false;
-		if ( isset( $_GET['client_id'] ) && empty( $this->settings->client_id ) ) {
-			$this->settings->client_id = sanitize_text_field( $_GET['client_id'] );
-			$this->settings->save();
-			$show_succeeded = true;
-			$this->logger->log("Client ID set through Quickstart: " . $this->settings->client_id, 'quickstart');
-		}
+		$quickstart_uri = rest_url( 'hello-login/v1/quickstart' );
 
 		$custom_logo_url = '';
 		if ( has_custom_logo() ) {
@@ -500,7 +492,7 @@ class Hello_Login_Settings_Page {
 
 			<form method="get" action="https://quickstart.hello.coop/">
 				<input type="hidden" name="integration" id="integration" value="wordpress" />
-				<input type="hidden" name="response_uri" id="response_uri" value="<?php print esc_attr( $plugin_settings_uri ); ?>" />
+				<input type="hidden" name="response_uri" id="response_uri" value="<?php print esc_attr( $quickstart_uri ); ?>" />
 				<input type="hidden" name="name" id="name" value="<?php print esc_attr( get_bloginfo('name') ); ?>" />
 				<input type="hidden" name="pp_uri" id="pp_uri" value="<?php print esc_attr( get_privacy_policy_url() ); ?>" />
 				<input type="hidden" name="image_uri" id="image_uri" value="<?php print esc_attr( $custom_logo_url ); ?>" />
@@ -509,8 +501,6 @@ class Hello_Login_Settings_Page {
 			</form>
 
 			<?php } else { ?>
-
-			<?php if ( $show_succeeded ) { ?><p id="quickstart_success">Quickstart Succeeded!</p><?php } ?>
 
 			<?php if ( empty( get_user_meta( get_current_user_id(), 'hello-login-subject-identity', true ) ) ) { ?>
 				<p id="link-hello-wallet">You are logged in with a username and a password. Link your Hellō Wallet to use Hellō in the future.</p>

--- a/test-drive/README.md
+++ b/test-drive/README.md
@@ -55,6 +55,11 @@ Delete only the client id for the Hellō Login plugin settings:
 ./wp-cli.sh option patch delete hello_login_settings client_id
 ```
 
+Drop into a PHP shell:
+```shell
+./wp-cli.sh shell
+```
+
 ## Docker Cheat Sheet
 
 ### Bash Session Inside a Container

--- a/test-drive/README.md
+++ b/test-drive/README.md
@@ -25,9 +25,34 @@ List users:
 ./wp-cli.sh user list
 ```
 
+Get Hellō user id for user 1:
+```shell
+./wp-cli.sh user meta get 1 hello-login-subject-identity
+```
+
 Unlink user 1 from Hellō:
 ```shell
 ./wp-cli.sh user meta delete 1 hello-login-subject-identity
+```
+
+Get the Hellō Login plugin settings:
+```shell
+./wp-cli.sh option get hello_login_settings
+```
+
+Get the client id configured for the Hellō Login plugin:
+```shell
+./wp-cli.sh option pluck hello_login_settings client_id
+```
+
+Delete all settings for the Hellō Login plugin:
+```shell
+./wp-cli.sh option delete hello_login_settings
+```
+
+Delete only the client id for the Hellō Login plugin settings:
+```shell
+./wp-cli.sh option patch delete hello_login_settings client_id
 ```
 
 ## Docker Cheat Sheet


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [plugin Contributing guideline](https://github.com/oidc-wp/openid-connect-generi/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

* new REST API endpoint to receive Quickstart responses
  * the REST API validates the responses, saves the client id and redirects to settings page
    * the client id is validated to be a UUID v4
  * settings page URL always clean now
* fixed configuration of redirect URI callback REST API
* added more examples of WordPress CLI commands


Closes #45  .

