### PR TITLE
fix clearing of client id field

### DIFF
--- a/includes/hello-login-client-wrapper.php
+++ b/includes/hello-login-client-wrapper.php
@@ -221,7 +221,7 @@ class Hello_Login_Client_Wrapper {
 			$client_id = sanitize_text_field( $request->get_param( 'client_id' ) );
 
 			// TODO add client id format validation
-\
+
 			if ( ! empty( $this->settings->client_id ) ) {
 				return new WP_Error( 'existing_client_id', 'Client id already set', array( 'status' => 403 ) );
 			}

--- a/includes/hello-login-settings-page.php
+++ b/includes/hello-login-settings-page.php
@@ -564,11 +564,12 @@ class Hello_Login_Settings_Page {
 	public function do_text_field( $field ) {
 		$disabled = ! empty( $field['disabled'] ) && boolval( $field['disabled'] ) === true;
 
+		$readonly = '';
 		if ( $field['key'] == 'client_id' ) {
-			$disabled = true;
+			$readonly = 'readonly';
 		}
 		?>
-		<input type="<?php print esc_attr( $field['type'] ); ?>"
+		<input type="<?php print esc_attr( $field['type'] ); ?>" <?php print esc_attr( $readonly ); ?>
 				<?php echo ( $disabled ? ' disabled' : '' ); ?>
 			  id="<?php print esc_attr( $field['key'] ); ?>"
 			  class="large-text<?php echo ( $disabled ? ' disabled' : '' ); ?>"


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [plugin Contributing guideline](https://github.com/oidc-wp/openid-connect-generi/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

* using `readonly` instead of `diabled` attribute for the client id input field fixes the issue
* fixed a typo in the Quickstart callback

Closes #39  .
