### PR TITLE
fix REST API caching and release version 1.0.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Hellō Login Changelog
 
+## 1.0.9
+
+* Fix: disable caching on REST API response
+* Improvement: enable logging by default
+* Improvement: content changes on plugin settings page
+
 ## 1.0.8
 
 * Fix: use query parameter based redirect URI

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 **Tags:** security, login, oauth2, openidconnect, apps, authentication, sso  
 **Requires at least:** 4.9  
 **Tested up to:** 6.1  
-**Stable tag:** 1.0.8  
+**Stable tag:** 1.0.9  
 **Requires PHP:** 7.2  
 **License:** GPLv2 or later  
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html  
@@ -79,6 +79,12 @@ Please submit to [https://github.com/hellocoop/wordpress/issues](https://github.
 2. The Hellō Wallet login choices offered.
 
 ## Changelog ##
+
+### 1.0.9 ###
+
+* Fix: disable caching on REST API response
+* Improvement: enable logging by default
+* Improvement: content changes on plugin settings page
 
 ### 1.0.8 ###
 

--- a/hello-login.php
+++ b/hello-login.php
@@ -380,7 +380,7 @@ class Hello_Login {
 				'create_if_does_not_exist' => defined( 'OIDC_CREATE_IF_DOES_NOT_EXIST' ) ? intval( OIDC_CREATE_IF_DOES_NOT_EXIST ) : 1,
 				'redirect_user_back' => defined( 'OIDC_REDIRECT_USER_BACK' ) ? intval( OIDC_REDIRECT_USER_BACK ) : 1,
 				'redirect_on_logout' => defined( 'OIDC_REDIRECT_ON_LOGOUT' ) ? intval( OIDC_REDIRECT_ON_LOGOUT ) : 1,
-				'enable_logging'  => 0,
+				'enable_logging'  => 1,
 				'log_limit'       => 1000,
 			)
 		);

--- a/hello-login.php
+++ b/hello-login.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Hellō Login
  * Plugin URI:        https://github.com/hellocoop/wordpress
  * Description:       Free and simple to setup plugin provides registration and login with the Hellō Wallet. Users choose from popular social login, email, or crypto wallet. Setup in 7 clicks, not 7 hours.
- * Version:           1.0.8
+ * Version:           1.0.9
  * Requires at least: 4.9
  * Requires PHP:      7.2
  * Author:            hellocoop
@@ -84,7 +84,7 @@ class Hello_Login {
 	 *
 	 * @var string
 	 */
-	const VERSION = '1.0.8';
+	const VERSION = '1.0.9';
 
 	/**
 	 * Plugin option name.

--- a/includes/hello-login-client-wrapper.php
+++ b/includes/hello-login-client-wrapper.php
@@ -187,7 +187,7 @@ class Hello_Login_Client_Wrapper {
 	 * Get the authentication URL for the REST API.
 	 *
 	 * @param WP_REST_Request $request The REST request object.
-	 * @return array|WP_Error A Hello service authentication URL.
+	 * @return WP_REST_Response|WP_Error A Hello service authentication URL.
 	 */
 	public function rest_auth_url( WP_REST_Request $request ) {
 		$atts = array();
@@ -209,9 +209,14 @@ class Hello_Login_Client_Wrapper {
 			);
 		}
 
-		return array(
+		$body = array(
 			'url' => $this->get_authentication_url( $atts ),
 		);
+
+		$response = new WP_REST_Response( $body );
+		$response->set_headers( array( 'Cache-Control' => 'no-cache' ) );
+
+		return $response;
 	}
 
 	/**

--- a/includes/hello-login-settings-page.php
+++ b/includes/hello-login-settings-page.php
@@ -517,17 +517,6 @@ class Hello_Login_Settings_Page {
 				?>
 			</form>
 
-			<?php } ?>
-
-			<?php if ( isset( $_GET['debug'] ) ) { ?>
-				<h4>Debug</h4>
-				<p>Hellō user id: <code><?php print esc_html( get_user_meta( get_current_user_id(), 'hello-login-subject-identity', true ) ) ?></code></p>
-				<pre>
-				<?php print esc_html( var_dump( $this->settings->get_values() ) ); ?>
-				</pre>
-			}
-			<?php } ?>
-
 			<h4><?php esc_html_e( 'Notes', 'hello-login' ); ?></h4>
 
 			<p class="description">
@@ -542,6 +531,17 @@ class Hello_Login_Settings_Page {
 				<strong><?php esc_html_e( 'Authentication URL Shortcode', 'hello-login' ); ?></strong>
 				<code>[hello_login_auth_url]</code>
 			</p>
+
+			<?php } ?>
+
+			<?php if ( isset( $_GET['debug'] ) ) { ?>
+				<h4>Debug</h4>
+				<p>Hellō user id: <code><?php print esc_html( get_user_meta( get_current_user_id(), 'hello-login-subject-identity', true ) ) ?></code></p>
+				<pre>
+				<?php print esc_html( var_dump( $this->settings->get_values() ) ); ?>
+				</pre>
+			}
+			<?php } ?>
 
 			<?php if ( $this->settings->enable_logging ) { ?>
 				<h2><?php esc_html_e( 'Logs', 'hello-login' ); ?></h2>

--- a/languages/hello-login.pot
+++ b/languages/hello-login.pot
@@ -2,7 +2,7 @@
 # This file is distributed under the GPL-2.0+.
 msgid ""
 msgstr ""
-"Project-Id-Version: Hellō Login 1.0.8\n"
+"Project-Id-Version: Hellō Login 1.0.9\n"
 "Report-Msgid-Bugs-To: "
 "https://github.com/hellocoop/wordpress/issues\n"
 "POT-Creation-Date: 2022-08-19 04:06:16+00:00\n"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hello-login",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "hello-login",
-	"version": "1.0.8",
+	"version": "1.0.9",
 	"description": "Hellō WordPress plugin.",
 	"main": "Gruntfile.js",
 	"repository": {

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://www.hello.dev/
 Tags: security, login, oauth2, openidconnect, apps, authentication, sso
 Requires at least: 4.9
 Tested up to: 6.1
-Stable tag: 1.0.8
+Stable tag: 1.0.9
 Requires PHP: 7.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/readme.txt
+++ b/readme.txt
@@ -80,6 +80,12 @@ Please submit to [https://github.com/hellocoop/wordpress/issues](https://github.
 
 == Changelog ==
 
+= 1.0.9 =
+
+* Fix: disable caching on REST API response
+* Improvement: enable logging by default
+* Improvement: content changes on plugin settings page
+
 = 1.0.8 =
 
 * Fix: use query parameter based redirect URI


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [plugin Contributing guideline](https://github.com/oidc-wp/openid-connect-generi/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

* disable caching of REST API response for `/hello-login/v1/auth_url`
* new version 1.0.9
* enable logging by default
* content changes on plugin settings page

Closes #58  .
