### PR TITLE
login page layout fixes Lost password and logged out

### DIFF
--- a/hello-login.php
+++ b/hello-login.php
@@ -174,7 +174,7 @@ class Hello_Login {
 			return;
 		}
 
-		Hello_Login_Login_Form::register( $this->settings, $this->client_wrapper );
+		Hello_Login_Login_Form::register( $this->logger, $this->settings, $this->client_wrapper );
 
 		// Add a shortcode to get the auth URL.
 		add_shortcode( 'hello_login_auth_url', array( $this->client_wrapper, 'get_authentication_url' ) );

--- a/includes/hello-login-login-form.php
+++ b/includes/hello-login-login-form.php
@@ -65,7 +65,7 @@ class Hello_Login_Login_Form {
 		$login_form = new self( $logger, $settings, $client_wrapper );
 
 		// Alter the login form as dictated by settings.
-		add_filter( 'login_message', array( $login_form, 'handle_login_page' ), 99 );
+		add_filter( 'login_messages', array( $login_form, 'handle_login_page' ), 99 );
 
 		// Add a shortcode for the login button.
 		add_shortcode( 'hello_login_button', array( $login_form, 'make_login_button' ) );

--- a/includes/hello-login-login-form.php
+++ b/includes/hello-login-login-form.php
@@ -101,7 +101,10 @@ class Hello_Login_Login_Form {
 			$message .= $this->make_error_output( sanitize_text_field( wp_unslash( $_GET['login-error'] ) ), $error_message );
 		}
 
-		if ( ! empty( $this->settings->client_id ) ) {
+		$configured = !empty($this->settings->client_id);
+		$on_lost_password = isset( $_GET['action'] ) && 'lostpassword' == $_GET['action'];
+
+		if ( $configured && ! $on_lost_password ) {
 			// Login button is appended to existing messages in case of error.
 			$atts = array(
 				'redirect_to' => home_url(),

--- a/includes/hello-login-login-form.php
+++ b/includes/hello-login-login-form.php
@@ -20,6 +20,13 @@
 class Hello_Login_Login_Form {
 
 	/**
+	 * Plugin logger.
+	 *
+	 * @var Hello_Login_Option_Logger
+	 */
+	private $logger;
+
+	/**
 	 * Plugin settings object.
 	 *
 	 * @var Hello_Login_Option_Settings
@@ -36,10 +43,12 @@ class Hello_Login_Login_Form {
 	/**
 	 * The class constructor.
 	 *
+	 * @param Hello_Login_Option_Logger   $logger         Plugin logs.
 	 * @param Hello_Login_Option_Settings $settings       A plugin settings object instance.
 	 * @param Hello_Login_Client_Wrapper  $client_wrapper A plugin client wrapper object instance.
 	 */
-	public function __construct( $settings, $client_wrapper ) {
+	public function __construct( $logger, $settings, $client_wrapper ) {
+		$this->logger = $logger;
 		$this->settings = $settings;
 		$this->client_wrapper = $client_wrapper;
 	}
@@ -52,8 +61,8 @@ class Hello_Login_Login_Form {
 	 *
 	 * @return void
 	 */
-	public static function register( $settings, $client_wrapper ) {
-		$login_form = new self( $settings, $client_wrapper );
+	public static function register( $logger, $settings, $client_wrapper ) {
+		$login_form = new self( $logger, $settings, $client_wrapper );
 
 		// Alter the login form as dictated by settings.
 		add_filter( 'login_message', array( $login_form, 'handle_login_page' ), 99 );

--- a/includes/hello-login-login-form.php
+++ b/includes/hello-login-login-form.php
@@ -112,8 +112,9 @@ class Hello_Login_Login_Form {
 
 		$configured = !empty($this->settings->client_id);
 		$on_lost_password = isset( $_GET['action'] ) && 'lostpassword' == $_GET['action'];
+		$on_register = isset( $_GET['action'] ) && 'register' == $_GET['action'];
 
-		if ( $configured && ! $on_lost_password ) {
+		if ( $configured && ! $on_lost_password && ! $on_register) {
 			// Login button is appended to existing messages in case of error.
 			$atts = array(
 				'redirect_to' => home_url(),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [plugin Contributing guideline](https://github.com/oidc-wp/openid-connect-generi/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

* no Hello button on lost password and register pages
* logout and other messages at the top and not in the middle
