### PR TITLE
from login page send users to admin area

### DIFF
--- a/includes/hello-login-login-form.php
+++ b/includes/hello-login-login-form.php
@@ -117,7 +117,7 @@ class Hello_Login_Login_Form {
 		if ( $configured && ! $on_lost_password && ! $on_register) {
 			// Login button is appended to existing messages in case of error.
 			$atts = array(
-				'redirect_to' => home_url(),
+				'redirect_to' => admin_url(),
 			);
 
 			$message .= $this->make_login_button($atts);

--- a/includes/hello-login-login-form.php
+++ b/includes/hello-login-login-form.php
@@ -65,7 +65,7 @@ class Hello_Login_Login_Form {
 		$login_form = new self( $logger, $settings, $client_wrapper );
 
 		// Alter the login form as dictated by settings.
-		add_filter( 'login_messages', array( $login_form, 'handle_login_page' ), 99 );
+		add_filter( 'login_message', array( $login_form, 'handle_login_page' ), 99 );
 
 		// Add a shortcode for the login button.
 		add_shortcode( 'hello_login_button', array( $login_form, 'make_login_button' ) );

--- a/test-drive/wp-cli.sh
+++ b/test-drive/wp-cli.sh
@@ -1,10 +1,10 @@
 #!/bin/sh
 
 docker run -it --rm \
---volumes-from test-drive-hello_wordpress-1 \
---network container:test-drive-hello_wordpress-1 \
+--volumes-from hello-login-wordpress-1 \
+--network container:hello-login-wordpress-1 \
 -e WORDPRESS_DB_USER=exampleuser \
 -e WORDPRESS_DB_PASSWORD=examplepass \
 -e WORDPRESS_DB_NAME=exampledb \
--e WORDPRESS_DB_HOST=hello_db \
+-e WORDPRESS_DB_HOST=db \
 wordpress:cli "$@"


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [plugin Contributing guideline](https://github.com/oidc-wp/openid-connect-generi/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

* when logging in from `wp-login.php` send user to admin area instead of home url
* revert filtering on login_messages
* fix docker container name in wp-cli

Closes #57  .
