### PR TITLE
insert Hello button based on logged out state

### DIFF
--- a/includes/hello-login-login-form.php
+++ b/includes/hello-login-login-form.php
@@ -56,6 +56,7 @@ class Hello_Login_Login_Form {
 	/**
 	 * Create an instance of the Hello_Login_Login_Form class.
 	 *
+	 * @param Hello_Login_Option_Logger   $logger   The plugin logging class object.
 	 * @param Hello_Login_Option_Settings $settings       A plugin settings object instance.
 	 * @param Hello_Login_Client_Wrapper  $client_wrapper A plugin client wrapper object instance.
 	 *
@@ -64,8 +65,14 @@ class Hello_Login_Login_Form {
 	public static function register( $logger, $settings, $client_wrapper ) {
 		$login_form = new self( $logger, $settings, $client_wrapper );
 
+		$on_logged_out = isset( $_GET['loggedout'] ) && 'true' == $_GET['loggedout'];
+
 		// Alter the login form as dictated by settings.
-		add_filter( 'login_message', array( $login_form, 'handle_login_page' ), 99 );
+		if ( $on_logged_out ) {
+			add_filter( 'login_messages', array( $login_form, 'handle_login_page' ), 99 );
+		} else {
+			add_filter( 'login_message', array( $login_form, 'handle_login_page' ), 99 );
+		}
 
 		// Add a shortcode for the login button.
 		add_shortcode( 'hello_login_button', array( $login_form, 'make_login_button' ) );

--- a/includes/hello-login-settings-page.php
+++ b/includes/hello-login-settings-page.php
@@ -510,7 +510,7 @@ class Hello_Login_Settings_Page {
 				<button class="hello-btn" data-label="ō&nbsp;&nbsp;&nbsp;Link Hellō" onclick="navigateToHelloAuthRequestUrl('<?php print esc_js( $api_url ); ?>', '')"></button>
 			<?php } ?>
 
-			<p><h2>Use the <a href="https://console.hello.coop/" target="_blank">Hellō Console</a> to update the name, images, terms of service, and privacy policy displayed by Hellō when logging in.<h2></p>
+			<h2>Use the <a href="https://console.hello.coop/" target="_blank">Hellō Console</a> to update the name, images, terms of service, and privacy policy displayed by Hellō when logging in.<h2>
 
 			<form method="post" action="options.php">
 				<?php


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [plugin Contributing guideline](https://github.com/oidc-wp/openid-connect-generi/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

* detect when on "logged out" page and use different strategy to insert Hello button

Addresses part of #67  .

![loggedout](https://user-images.githubusercontent.com/942078/206574496-f3b81cb3-361b-4dd6-93bb-a86f6ae5b6bb.png)
