### PR TITLE
restructure settings page

### DIFF
--- a/hello-login.php
+++ b/hello-login.php
@@ -151,7 +151,7 @@ class Hello_Login {
 
 		$redirect_uri = site_url( '?hello-login=callback' );
 
-		$state_time_limit = 180;
+		$state_time_limit = 600;
 		if ( $this->settings->state_time_limit ) {
 			$state_time_limit = intval( $this->settings->state_time_limit );
 		}

--- a/includes/hello-login-client.php
+++ b/includes/hello-login-client.php
@@ -92,13 +92,13 @@ class Hello_Login_Client {
 	private $acr_values;
 
 	/**
-	 * The state time limit. States are only valid for 3 minutes.
+	 * The state time limit. States are only valid for 10 minutes.
 	 *
 	 * @see Hello_Login_Option_Settings::state_time_limit
 	 *
 	 * @var int
 	 */
-	private $state_time_limit = 180;
+	private $state_time_limit = 600;
 
 	/**
 	 * The logger object instance.

--- a/includes/hello-login-settings-page.php
+++ b/includes/hello-login-settings-page.php
@@ -246,18 +246,24 @@ class Hello_Login_Settings_Page {
 			),
 			*/
 			'scope'             => array(
-					'title'       => __( 'Scopes', 'hello-login' ),
-					'description' => __( 'The default scopes gather the default user properties. Only modify after reviewing available claims at https://www.hello.dev/documentation/hello-claims.html.', 'hello-login' ),
-					'example'     => 'openid name nickname family_name given_name email',
-					'type'        => 'text',
-					'disabled'    => defined( 'OIDC_CLIENT_SCOPE' ),
-					'section'     => 'client_settings',
+				'title'       => __( 'Scopes', 'hello-login' ),
+				'description' => __( 'The default scopes gather the default user properties. Only modify after reviewing available claims at https://www.hello.dev/documentation/hello-claims.html.', 'hello-login' ),
+				'example'     => 'openid name nickname family_name given_name email',
+				'type'        => 'text',
+				'disabled'    => defined( 'OIDC_CLIENT_SCOPE' ),
+				'section'     => 'client_settings',
 			),
 			'client_id'         => array(
 				'title'       => __( 'Client ID', 'hello-login' ),
 				'description' => __( 'The client identifier provided by Hellō and set by Quickstart.', 'hello-login' ),
 				'type'        => 'text',
 				'disabled'    => defined( 'OIDC_CLIENT_ID' ),
+				'section'     => 'client_settings',
+			),
+			'redirect_uri'         => array(
+				'title'       => __( 'Redirect URI', 'hello-login' ),
+				'description' => __( 'The endpoint used to receive authentication data.', 'hello-login' ),
+				'type'        => 'text',
 				'section'     => 'client_settings',
 			),
 			/*
@@ -525,6 +531,13 @@ class Hello_Login_Settings_Page {
 
 			<h2>Use the <a href="https://console.hello.coop/" target="_blank">Hellō Console</a> to update the name, images, terms of service, and privacy policy displayed by Hellō when logging in.<h2>
 
+			<h2>Hellō Button</h2>
+			<p>In order to add a "Continue with Hellō" button you have the following options:
+				<ul style="list-style-type:disc; padding-left: 3em">
+					<li>Shortcode: <code>[hello_login_button]</code></li>
+					<li>Block: <em>coming soon...</em></li>
+				</ul>
+			</p>
 			<form method="post" action="options.php">
 				<?php
 				settings_fields( $this->settings_field_group );
@@ -566,10 +579,15 @@ class Hello_Login_Settings_Page {
 	 */
 	public function do_text_field( $field ) {
 		$disabled = ! empty( $field['disabled'] ) && boolval( $field['disabled'] ) === true;
+		$value = $this->settings->{ $field['key'] };
 
 		$readonly = '';
 		if ( $field['key'] == 'client_id' ) {
 			$readonly = 'readonly';
+		}
+		if ( $field['key'] == 'redirect_uri' ) {
+			$readonly = 'readonly';
+			$value = site_url( '?hello-login=callback' );
 		}
 		?>
 		<input type="<?php print esc_attr( $field['type'] ); ?>" <?php print esc_attr( $readonly ); ?>
@@ -577,7 +595,7 @@ class Hello_Login_Settings_Page {
 			  id="<?php print esc_attr( $field['key'] ); ?>"
 			  class="large-text<?php echo ( $disabled ? ' disabled' : '' ); ?>"
 			  name="<?php print esc_attr( $field['name'] ); ?>"
-			  value="<?php print esc_attr( $this->settings->{ $field['key'] } ); ?>">
+			  value="<?php print esc_attr( $value ); ?>">
 		<?php
 		$this->do_field_description( $field );
 	}

--- a/includes/hello-login-settings-page.php
+++ b/includes/hello-login-settings-page.php
@@ -151,17 +151,17 @@ class Hello_Login_Settings_Page {
 		);
 
 		add_settings_section(
-			'client_settings',
-			__( 'Client Settings', 'hello-login' ),
-			array( $this, 'client_settings_description' ),
-			$this->options_page_name
-		);
-
-		add_settings_section(
 				'user_settings',
 				__('User Settings', 'hello-login'),
 				array($this, 'user_settings_description'),
 				$this->options_page_name
+		);
+
+		add_settings_section(
+			'client_settings',
+			__( 'Client Settings', 'hello-login' ),
+			array( $this, 'client_settings_description' ),
+			$this->options_page_name
 		);
 
 		if ( isset( $_GET['debug'] ) ) {

--- a/includes/hello-login-settings-page.php
+++ b/includes/hello-login-settings-page.php
@@ -245,6 +245,14 @@ class Hello_Login_Settings_Page {
 				'section'     => 'client_settings',
 			),
 			*/
+			'scope'             => array(
+					'title'       => __( 'Scopes', 'hello-login' ),
+					'description' => __( 'The default scopes gather the default user properties. Only modify after reviewing available claims at https://www.hello.dev/documentation/hello-claims.html.', 'hello-login' ),
+					'example'     => 'openid name nickname family_name given_name email',
+					'type'        => 'text',
+					'disabled'    => defined( 'OIDC_CLIENT_SCOPE' ),
+					'section'     => 'client_settings',
+			),
 			'client_id'         => array(
 				'title'       => __( 'Client ID', 'hello-login' ),
 				'description' => __( 'The client identifier provided by Hellō and set by Quickstart.', 'hello-login' ),
@@ -261,14 +269,6 @@ class Hello_Login_Settings_Page {
 				'section'     => 'client_settings',
 			),
 			*/
-			'scope'             => array(
-				'title'       => __( 'Scopes', 'hello-login' ),
-				'description' => __( 'The default scopes gather the default user properties. Only modify after reviewing available claims at https://www.hello.dev/documentation/hello-claims.html.', 'hello-login' ),
-				'example'     => 'openid name nickname family_name given_name email',
-				'type'        => 'text',
-				'disabled'    => defined( 'OIDC_CLIENT_SCOPE' ),
-				'section'     => 'client_settings',
-			),
 			/*
 			'endpoint_login'    => array(
 				'title'       => __( 'Login Endpoint URL', 'hello-login' ),

--- a/includes/hello-login-settings-page.php
+++ b/includes/hello-login-settings-page.php
@@ -543,10 +543,6 @@ class Hello_Login_Settings_Page {
 				<strong><?php esc_html_e( 'Login Button Shortcode', 'hello-login' ); ?></strong>
 				<code>[hello_login_button]</code>
 			</p>
-			<p class="description">
-				<strong><?php esc_html_e( 'Authentication URL Shortcode', 'hello-login' ); ?></strong>
-				<code>[hello_login_auth_url]</code>
-			</p>
 
 			<?php } ?>
 

--- a/includes/hello-login-settings-page.php
+++ b/includes/hello-login-settings-page.php
@@ -490,7 +490,20 @@ class Hello_Login_Settings_Page {
 			<h2><?php print esc_html( get_admin_page_title() ); ?></h2>
 
 			<?php if ( ! $configured ) { ?>
-			<p><h2>To use Hellō, you must configure your site. Hellō Quickstart will get you up and running in seconds. You will create a Hellō Wallet if you don't have one already.</h2></p>
+			<h2>To use Hellō, you must configure your site. Hellō Quickstart will get you up and running in seconds. You will create a Hellō Wallet if you don't have one already.</h2>
+
+			<p>The following information is sent with the Quickstart request:
+				<ul style="list-style-type:disc; padding-left: 3em">
+					<li>Site Name: <strong><?php print esc_html( get_bloginfo('name') ); ?></strong></li>
+					<?php if ( $custom_logo_url ) { ?>
+					<li>Site Logo: <img src="<?php print esc_attr( $custom_logo_url ); ?>" alt="Site Logo" height="70" /></li>
+					<?php } ?>
+					<?php if ( get_privacy_policy_url() ) { ?>
+					<li>Privacy Policy URL: <code><?php print esc_html( get_privacy_policy_url() ); ?></code></li>
+					<?php } ?>
+					<li>Redirect URI: <code><?php print esc_html( $redirect_uri ); ?></code></li>
+				</ul>
+			</p>
 
 			<form method="get" action="https://quickstart.hello.coop/">
 				<input type="hidden" name="integration" id="integration" value="wordpress" />

--- a/includes/hello-login-settings-page.php
+++ b/includes/hello-login-settings-page.php
@@ -532,18 +532,6 @@ class Hello_Login_Settings_Page {
 				submit_button();
 				?>
 			</form>
-
-			<h4><?php esc_html_e( 'Notes', 'hello-login' ); ?></h4>
-
-			<p class="description">
-				<strong><?php esc_html_e( 'Redirect URI', 'hello-login' ); ?></strong>
-				<code><?php print esc_url( $redirect_uri ); ?></code>
-			</p>
-			<p class="description">
-				<strong><?php esc_html_e( 'Login Button Shortcode', 'hello-login' ); ?></strong>
-				<code>[hello_login_button]</code>
-			</p>
-
 			<?php } ?>
 
 			<?php if ( $debug ) { ?>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [plugin Contributing guideline](https://github.com/oidc-wp/openid-connect-generi/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

* restructured the settings page
* hid the `hello_login_auth_url` shortcode
* increased state time limit from 3 to 10 minutes
* added information about data being sent by Quickstart

Closes #71  .
