### PR TITLE
add Hellō link/unlink buttons to profile page

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -18,9 +18,16 @@ add_action( 'wp_enqueue_scripts', 'hello_login_enqueue_scripts_and_styles' );
 add_action( 'login_enqueue_scripts', 'hello_login_enqueue_scripts_and_styles' );
 add_action( 'admin_enqueue_scripts', 'hello_login_enqueue_scripts_and_styles' );
 
+/**
+ * Show Hellō account linking controls on the profile page.
+ *
+ * @param WP_User $profileuser The user whose profile is being edited.
+ * @return void
+ */
 function hello_login_user_profile( $profileuser ) {
 	$api_url = rest_url( 'hello-login/v1/auth_url' );
 	$hello_user_id = get_user_meta( $profileuser->ID, 'hello-login-subject-identity', true );
+	$unlink_url = site_url( '?hello-login=unlink' );
 	?>
 	<h2>Hellō Login</h2>
 	<table class="form-table">
@@ -28,9 +35,9 @@ function hello_login_user_profile( $profileuser ) {
 			<th>Hellō Wallet</th>
 			<td>
 				<?php if ( empty( $hello_user_id ) ) { ?>
-					<button class="hello-btn" data-label="ō&nbsp;&nbsp;&nbsp;Link Hellō" onclick="navigateToHelloAuthRequestUrl('<?php print esc_js( $api_url ); ?>', '')"></button>
+					<button type="button" class="hello-btn" data-label="ō&nbsp;&nbsp;&nbsp;Link Hellō" onclick="navigateToHelloAuthRequestUrl('<?php print esc_js( $api_url ); ?>', '')"></button>
 				<?php } else { ?>
-					<button class="hello-btn" data-label="ō&nbsp;&nbsp;&nbsp;Unlink Hellō" onclick="navigateToHelloAuthRequestUrl('<?php print esc_js( $api_url ); ?>', '')"></button>
+					<button type="button" class="hello-btn" data-label="ō&nbsp;&nbsp;&nbsp;Unlink Hellō" onclick="parent.location='<?php print esc_js( $unlink_url ); ?>'"></button>
 				<?php } ?>
 			</td>
 		</tr>

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -37,7 +37,7 @@ function hello_login_user_profile( $profileuser ) {
 				<?php if ( empty( $hello_user_id ) ) { ?>
 					<button type="button" class="hello-btn" data-label="ō&nbsp;&nbsp;&nbsp;Link Hellō" onclick="navigateToHelloAuthRequestUrl('<?php print esc_js( $api_url ); ?>', '')"></button>
 				<?php } else { ?>
-					<button type="button" class="hello-btn" data-label="ō&nbsp;&nbsp;&nbsp;Unlink Hellō" onclick="parent.location='<?php print esc_js( $unlink_url ); ?>'"></button>
+					<button type="button" class="button" onclick="parent.location='<?php print esc_js( $unlink_url ); ?>'">ō&nbsp;&nbsp;&nbsp;Unlink Hellō</button>
 				<?php } ?>
 			</td>
 		</tr>

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -17,3 +17,25 @@ function hello_login_enqueue_scripts_and_styles() {
 add_action( 'wp_enqueue_scripts', 'hello_login_enqueue_scripts_and_styles' );
 add_action( 'login_enqueue_scripts', 'hello_login_enqueue_scripts_and_styles' );
 add_action( 'admin_enqueue_scripts', 'hello_login_enqueue_scripts_and_styles' );
+
+function hello_login_user_profile( $profileuser ) {
+	$api_url = rest_url( 'hello-login/v1/auth_url' );
+	$hello_user_id = get_user_meta( $profileuser->ID, 'hello-login-subject-identity', true );
+	?>
+	<h2>Hellō Login</h2>
+	<table class="form-table">
+		<tr>
+			<th>Hellō Wallet</th>
+			<td>
+				<?php if ( empty( $hello_user_id ) ) { ?>
+					<button class="hello-btn" data-label="ō&nbsp;&nbsp;&nbsp;Link Hellō" onclick="navigateToHelloAuthRequestUrl('<?php print esc_js( $api_url ); ?>', '')"></button>
+				<?php } else { ?>
+					<button class="hello-btn" data-label="ō&nbsp;&nbsp;&nbsp;Unlink Hellō" onclick="navigateToHelloAuthRequestUrl('<?php print esc_js( $api_url ); ?>', '')"></button>
+				<?php } ?>
+			</td>
+		</tr>
+	</table>
+	<?php
+}
+
+add_action( 'show_user_profile', 'hello_login_user_profile' );

--- a/includes/hello-login-client-wrapper.php
+++ b/includes/hello-login-client-wrapper.php
@@ -152,6 +152,10 @@ class Hello_Login_Client_Wrapper {
 				$this->authentication_request_callback();
 				exit;
 			}
+			if ( 'unlink' === $query->query_vars['hello-login'] ) {
+				$this->unlink_hello();
+				exit;
+			}
 		}
 
 		return $query;
@@ -740,6 +744,32 @@ class Hello_Login_Client_Wrapper {
 
 		wp_redirect( $redirect_url );
 
+		exit;
+	}
+
+	/**
+	 * Unlink the current WordPress user from Hellō user.
+	 *
+	 * @return void
+	 */
+	public function unlink_hello() {
+		$this->logger->log( 'Start...', 'unlink_hello' );
+		$wp_user_id = get_current_user_id();
+
+		if ( $wp_user_id == 0 ) {
+			$this->logger->log( 'No current user', 'unlink_hello' );
+		} else {
+			$hello_user_id = get_user_meta( $wp_user_id, 'hello-login-subject-identity', true );
+
+			if ( empty( $hello_user_id ) ) {
+				$this->logger->log( 'User not linked', 'unlink_hello' );
+			} else {
+				delete_user_meta( $wp_user_id, 'hello-login-subject-identity' );
+				$this->logger->log( "WordPress user $wp_user_id unlinked from Hellō user $hello_user_id.", 'unlink_hello' );
+			}
+		}
+
+		wp_redirect( get_edit_profile_url( $wp_user_id ) );
 		exit;
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [plugin Contributing guideline](https://github.com/oidc-wp/openid-connect-generi/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

* add a "Hellō Login" section to profile page with Link and Unlink buttons

Closes #68  .

![hello_link](https://user-images.githubusercontent.com/942078/207173800-9d061546-a9e4-4371-ab8d-df0ac7717a17.png)

![hello_unlink](https://user-images.githubusercontent.com/942078/207184378-778ba7fc-e7e2-4a6c-9adf-76eeb4f53009.png)


