### PR TITLE
redirect to settings page after plugin activation

### DIFF
--- a/hello-login.php
+++ b/hello-login.php
@@ -282,7 +282,21 @@ class Hello_Login {
 	 */
 	public static function activation() {
 		self::setup_cron_jobs();
-		update_option('hello_login_permalinks_flushed', 0);
+		update_option( 'hello_login_permalinks_flushed', 0 );
+	}
+
+	/**
+	 * Redirect after plugin Activation hook.
+	 *
+	 * @param string $plugin The slug of the plugin being activated.
+	 *
+	 * @return void
+	 */
+	public static function activation_redirect( $plugin ) {
+		if( $plugin == plugin_basename( __FILE__ ) ) {
+			wp_redirect( admin_url( '/options-general.php?page=hello-login-settings' ) );
+			exit();
+		}
 	}
 
 	/**
@@ -414,6 +428,7 @@ class Hello_Login {
 Hello_Login::instance();
 
 register_activation_hook( __FILE__, array( 'Hello_Login', 'activation' ) );
+add_action( 'activated_plugin', array( 'Hello_Login', 'activation_redirect' ) );
 register_deactivation_hook( __FILE__, array( 'Hello_Login', 'deactivation' ) );
 register_uninstall_hook( __FILE__, array( 'Hello_Login', 'uninstall' ) );
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [plugin Contributing guideline](https://github.com/oidc-wp/openid-connect-generi/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

* redirect to plugin settings page right after plugin activation


Closes #79  .
