### PR TITLE
add admin notices for Quickstart and link/unlink actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,14 +13,14 @@ Free and simple to setup plugin provides registration and login with the Hellō 
 
 ## Description ##
 
-Provide your users a registration and login using their choice of popular social login, email, or even a crypto wallet. No need for you to configure your application at each provider or pay for a premium plugin.
+Provide your users registration and login using their choice of popular social login, email, or phone. No need for you to configure your application at each provider or pay for a premium plugin.
 
 Hellō Login verifies your users' email addresses so you don't have to. No longer do they have to manage another username and password to use your site.
 
 Hellō is a cloud identity wallet cooperatively operated with a mission to empower users to control their identity. Learn more at [hello.coop](https://www.hello.coop/).
 
-* Hellō Login installs with Hellō Quickstart to get you up and running in seconds.
-* Users control their identity with their Hellō Wallet. No need for you to manage how they login.
+* Hellō Login installs with Hellō Quickstart to get you up and running in 7 clicks.
+* Users manage how they login at [wallet.hello.coop](https://wallet.hello.coop). No need for you to manage how they login or help them recover their account.
 * Hellō Login is free for users and early adopting sites. See [hello.coop](https://www.hello.coop/) for details.
 
 Documentation, configuration, and settings can be found in Settings >  Hellō Login

--- a/hello-login.php
+++ b/hello-login.php
@@ -229,7 +229,7 @@ class Hello_Login {
 	 */
 	public function hello_login_user_profile_other( $profileuser ) {
 		$hello_user_id = get_user_meta( $profileuser->ID, 'hello-login-subject-identity', true );
-		$unlink_url = site_url( '?hello-login=unlink' );
+		$unlink_url = site_url( '?hello-login=unlink&user_id=' . $profileuser->ID );
 		?>
 		<h2>Hellō</h2>
 		<table class="form-table">

--- a/hello-login.php
+++ b/hello-login.php
@@ -396,6 +396,7 @@ class Hello_Login {
 				'redirect_on_logout' => defined( 'OIDC_REDIRECT_ON_LOGOUT' ) ? intval( OIDC_REDIRECT_ON_LOGOUT ) : 1,
 				'enable_logging'  => 0,
 				'log_limit'       => 1000,
+				'link_not_now'    => 0,
 			)
 		);
 

--- a/hello-login.php
+++ b/hello-login.php
@@ -203,7 +203,7 @@ class Hello_Login {
 	public function hello_login_user_profile_self( $profileuser ) {
 		$api_url = rest_url( 'hello-login/v1/auth_url' );
 		$hello_user_id = get_user_meta( $profileuser->ID, 'hello-login-subject-identity', true );
-		$unlink_url = site_url( '?hello-login=unlink' );
+		$unlink_url = wp_nonce_url( site_url( '?hello-login=unlink' ), 'unlink' );
 		?>
 		<h2>Hellō</h2>
 		<table class="form-table">
@@ -229,7 +229,7 @@ class Hello_Login {
 	 */
 	public function hello_login_user_profile_other( $profileuser ) {
 		$hello_user_id = get_user_meta( $profileuser->ID, 'hello-login-subject-identity', true );
-		$unlink_url = site_url( '?hello-login=unlink&user_id=' . $profileuser->ID );
+		$unlink_url = wp_nonce_url( site_url( '?hello-login=unlink&user_id=' . $profileuser->ID ), 'unlink' );
 		?>
 		<h2>Hellō</h2>
 		<table class="form-table">

--- a/hello-login.php
+++ b/hello-login.php
@@ -187,6 +187,64 @@ class Hello_Login {
 		if ( is_admin() ) {
 			Hello_Login_Settings_Page::register( $this->settings, $this->client_wrapper, $this->logger );
 		}
+
+		if ( ! empty( $this->settings->client_id ) ) {
+			add_action('show_user_profile', array($this, 'hello_login_user_profile_self'));
+			add_action('edit_user_profile', array($this, 'hello_login_user_profile_other'));
+		}
+	}
+
+	/**
+	 * Show Hellō account linking controls on the user's own profile page.
+	 *
+	 * @param WP_User $profileuser The user whose profile is being edited.
+	 * @return void
+	 */
+	public function hello_login_user_profile_self( $profileuser ) {
+		$api_url = rest_url( 'hello-login/v1/auth_url' );
+		$hello_user_id = get_user_meta( $profileuser->ID, 'hello-login-subject-identity', true );
+		$unlink_url = site_url( '?hello-login=unlink' );
+		?>
+		<h2>Hellō</h2>
+		<table class="form-table">
+			<tr>
+				<th>This Account</th>
+				<td>
+					<?php if ( empty( $hello_user_id ) ) { ?>
+						<button type="button" class="hello-btn" data-label="ō&nbsp;&nbsp;&nbsp;Link with Hellō" onclick="navigateToHelloAuthRequestUrl('<?php print esc_js( $api_url ); ?>', '')"></button>
+					<?php } else { ?>
+						<button type="button" class="button" onclick="parent.location='<?php print esc_js( $unlink_url ); ?>'">ō&nbsp;&nbsp;&nbsp;Unlink from Hellō</button>
+					<?php } ?>
+				</td>
+			</tr>
+		</table>
+		<?php
+	}
+
+	/**
+	 * Show Hellō account linking controls on the user's own profile page.
+	 *
+	 * @param WP_User $profileuser The user whose profile is being edited.
+	 * @return void
+	 */
+	public function hello_login_user_profile_other( $profileuser ) {
+		$hello_user_id = get_user_meta( $profileuser->ID, 'hello-login-subject-identity', true );
+		$unlink_url = site_url( '?hello-login=unlink' );
+		?>
+		<h2>Hellō</h2>
+		<table class="form-table">
+			<tr>
+				<th>This Account</th>
+				<td>
+					<?php if ( empty( $hello_user_id ) ) { ?>
+						<p>Not linked with Hellō</p>
+					<?php } else { ?>
+						<button type="button" class="button" onclick="parent.location='<?php print esc_js( $unlink_url ); ?>'">ō&nbsp;&nbsp;&nbsp;Unlink from Hellō</button>
+					<?php } ?>
+				</td>
+			</tr>
+		</table>
+		<?php
 	}
 
 	/**

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -29,15 +29,15 @@ function hello_login_user_profile( $profileuser ) {
 	$hello_user_id = get_user_meta( $profileuser->ID, 'hello-login-subject-identity', true );
 	$unlink_url = site_url( '?hello-login=unlink' );
 	?>
-	<h2>Hellō Login</h2>
+	<h2>Hellō</h2>
 	<table class="form-table">
 		<tr>
-			<th>Hellō Wallet</th>
+			<th>This Account</th>
 			<td>
 				<?php if ( empty( $hello_user_id ) ) { ?>
-					<button type="button" class="hello-btn" data-label="ō&nbsp;&nbsp;&nbsp;Link Hellō" onclick="navigateToHelloAuthRequestUrl('<?php print esc_js( $api_url ); ?>', '')"></button>
+					<button type="button" class="hello-btn" data-label="ō&nbsp;&nbsp;&nbsp;Link with Hellō" onclick="navigateToHelloAuthRequestUrl('<?php print esc_js( $api_url ); ?>', '')"></button>
 				<?php } else { ?>
-					<button type="button" class="button" onclick="parent.location='<?php print esc_js( $unlink_url ); ?>'">ō&nbsp;&nbsp;&nbsp;Unlink Hellō</button>
+					<button type="button" class="button" onclick="parent.location='<?php print esc_js( $unlink_url ); ?>'">ō&nbsp;&nbsp;&nbsp;Unlink from Hellō</button>
 				<?php } ?>
 			</td>
 		</tr>

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -17,32 +17,3 @@ function hello_login_enqueue_scripts_and_styles() {
 add_action( 'wp_enqueue_scripts', 'hello_login_enqueue_scripts_and_styles' );
 add_action( 'login_enqueue_scripts', 'hello_login_enqueue_scripts_and_styles' );
 add_action( 'admin_enqueue_scripts', 'hello_login_enqueue_scripts_and_styles' );
-
-/**
- * Show Hellō account linking controls on the profile page.
- *
- * @param WP_User $profileuser The user whose profile is being edited.
- * @return void
- */
-function hello_login_user_profile( $profileuser ) {
-	$api_url = rest_url( 'hello-login/v1/auth_url' );
-	$hello_user_id = get_user_meta( $profileuser->ID, 'hello-login-subject-identity', true );
-	$unlink_url = site_url( '?hello-login=unlink' );
-	?>
-	<h2>Hellō</h2>
-	<table class="form-table">
-		<tr>
-			<th>This Account</th>
-			<td>
-				<?php if ( empty( $hello_user_id ) ) { ?>
-					<button type="button" class="hello-btn" data-label="ō&nbsp;&nbsp;&nbsp;Link with Hellō" onclick="navigateToHelloAuthRequestUrl('<?php print esc_js( $api_url ); ?>', '')"></button>
-				<?php } else { ?>
-					<button type="button" class="button" onclick="parent.location='<?php print esc_js( $unlink_url ); ?>'">ō&nbsp;&nbsp;&nbsp;Unlink from Hellō</button>
-				<?php } ?>
-			</td>
-		</tr>
-	</table>
-	<?php
-}
-
-add_action( 'show_user_profile', 'hello_login_user_profile' );

--- a/includes/hello-login-client-wrapper.php
+++ b/includes/hello-login-client-wrapper.php
@@ -156,6 +156,10 @@ class Hello_Login_Client_Wrapper {
 				$this->unlink_hello();
 				exit;
 			}
+			if ( 'quickstart' === $query->query_vars['hello-login'] ) {
+				$this->quickstart_callback();
+				exit;
+			}
 		}
 
 		return $query;
@@ -173,15 +177,6 @@ class Hello_Login_Client_Wrapper {
 			array(
 				'methods' => 'GET',
 				'callback' => array( $this, 'rest_auth_url' ),
-				'permission_callback' => function() { return ''; },
-			)
-		);
-		register_rest_route(
-			'hello-login/v1',
-			'/quickstart/',
-			array(
-				'methods' => 'GET',
-				'callback' => array( $this, 'rest_quickstart_callback'),
 				'permission_callback' => function() { return ''; },
 			)
 		);
@@ -226,14 +221,13 @@ class Hello_Login_Client_Wrapper {
 	/**
 	 * Process the Quickstart response.
 	 *
-	 * @param WP_REST_Request $request The REST request object.
 	 * @return void
 	 */
-	public function rest_quickstart_callback( WP_REST_Request $request ) {
+	public function quickstart_callback() {
 		$message_id = 'quickstart_success';
 
-		if ( $request->has_param( 'client_id' ) ) {
-			$client_id = sanitize_text_field( $request->get_param( 'client_id' ) );
+		if ( isset( $_GET['client_id'] ) ) {
+			$client_id = sanitize_text_field( $_GET['client_id'] );
 
 			// TODO add client id format validation.
 
@@ -757,7 +751,6 @@ class Hello_Login_Client_Wrapper {
 	 * @return void
 	 */
 	public function unlink_hello() {
-		$this->logger->log( 'Start...', 'unlink_hello' );
 		$wp_user_id = get_current_user_id();
 
 		if ( $wp_user_id == 0 ) {

--- a/includes/hello-login-client-wrapper.php
+++ b/includes/hello-login-client-wrapper.php
@@ -663,6 +663,7 @@ class Hello_Login_Client_Wrapper {
 
 		$link_error = new WP_Error( self::LINK_ERROR_CODE, __( self::LINK_ERROR_MESSAGE, 'hello-login' ) );
 		$link_error->add_data( $subject_identity );
+		$message_id = '';
 
 		if ( ! $user ) {
 			// A pre-existing Hellō mapped user wasn't found.
@@ -680,6 +681,7 @@ class Hello_Login_Client_Wrapper {
 				// link accounts
 				$user = wp_get_current_user();
 				add_user_meta( $user->ID, 'hello-login-subject-identity', (string) $subject_identity, true );
+				$message_id = 'link_success';
 			} else {
 				// no current user session and no user found based on 'sub'
 
@@ -738,6 +740,10 @@ class Hello_Login_Client_Wrapper {
 		// Only do redirect-user-back action hook when the plugin is configured for it.
 		if ( $this->settings->redirect_user_back ) {
 			do_action( 'hello-login-redirect-user-back', $redirect_url, $user );
+		}
+
+		if ( ! empty( $message_id ) ) {
+			$redirect_url .= ( parse_url( $redirect_url, PHP_URL_QUERY ) ? '&' : '?' ) . 'hello-login-msg=' . $message_id;
 		}
 
 		wp_redirect( $redirect_url );

--- a/includes/hello-login-client-wrapper.php
+++ b/includes/hello-login-client-wrapper.php
@@ -751,22 +751,27 @@ class Hello_Login_Client_Wrapper {
 	 * @return void
 	 */
 	public function unlink_hello() {
+		$message_id = 'unlink_success';
 		$wp_user_id = get_current_user_id();
 
 		if ( $wp_user_id == 0 ) {
 			$this->logger->log( 'No current user', 'unlink_hello' );
+			$message_id = 'unlink_no_session';
 		} else {
 			$hello_user_id = get_user_meta( $wp_user_id, 'hello-login-subject-identity', true );
 
 			if ( empty( $hello_user_id ) ) {
 				$this->logger->log( 'User not linked', 'unlink_hello' );
+				$message_id = 'unlink_not_linked';
 			} else {
 				delete_user_meta( $wp_user_id, 'hello-login-subject-identity' );
 				$this->logger->log( "WordPress user $wp_user_id unlinked from Hellō user $hello_user_id.", 'unlink_hello' );
 			}
 		}
 
-		wp_redirect( get_edit_profile_url( $wp_user_id ) );
+		$profile_url = get_edit_profile_url ($wp_user_id );
+		$profile_url .= ( parse_url( $profile_url, PHP_URL_QUERY ) ? '&' : '?' ) . 'hello-login-msg=' . $message_id;
+		wp_redirect( $profile_url );
 		exit;
 	}
 

--- a/includes/hello-login-settings-page.php
+++ b/includes/hello-login-settings-page.php
@@ -244,9 +244,10 @@ class Hello_Login_Settings_Page {
 	 * @return void
 	 */
 	public function admin_notice_quickstart_success() {
+		$site_name = get_bloginfo( 'name' );
 		?>
 		<div class="notice notice-success is-dismissible">
-			<p><?php esc_html_e( 'Quickstart succeeded!', 'hello-login' ); ?></p>
+			<p><?php esc_html_e( "Quickstart has successfully registered your site \"$site_name\" at Hellō!", 'hello-login' ); ?></p>
 		</div>
 		<?php
 	}
@@ -575,7 +576,7 @@ class Hello_Login_Settings_Page {
 
 			<p>The following information is sent with the Quickstart request:
 				<ul style="list-style-type:disc; padding-left: 3em">
-					<li>Site Name: <strong><?php print esc_html( get_bloginfo('name') ); ?></strong></li>
+					<li>Site Name: <strong><?php print esc_html( get_bloginfo( 'name' ) ); ?></strong></li>
 					<?php if ( $custom_logo_url ) { ?>
 					<li>Site Logo: <img src="<?php print esc_attr( $custom_logo_url ); ?>" alt="Site Logo" height="70" /></li>
 					<?php } ?>
@@ -589,7 +590,7 @@ class Hello_Login_Settings_Page {
 			<form method="get" action="https://quickstart.hello.coop/">
 				<input type="hidden" name="integration" id="integration" value="wordpress" />
 				<input type="hidden" name="response_uri" id="response_uri" value="<?php print esc_attr( $quickstart_uri ); ?>" />
-				<input type="hidden" name="name" id="name" value="<?php print esc_attr( get_bloginfo('name') ); ?>" />
+				<input type="hidden" name="name" id="name" value="<?php print esc_attr( get_bloginfo( 'name' ) ); ?>" />
 				<input type="hidden" name="pp_uri" id="pp_uri" value="<?php print esc_attr( get_privacy_policy_url() ); ?>" />
 				<input type="hidden" name="image_uri" id="image_uri" value="<?php print esc_attr( $custom_logo_url ); ?>" />
 				<input type="hidden" name="redirect_uri" id="redirect_uri" value="<?php print esc_attr( $redirect_uri ); ?>" />

--- a/includes/hello-login-settings-page.php
+++ b/includes/hello-login-settings-page.php
@@ -645,7 +645,7 @@ class Hello_Login_Settings_Page {
 				<input type="hidden" name="pp_uri" id="pp_uri" value="<?php print esc_attr( get_privacy_policy_url() ); ?>" />
 				<input type="hidden" name="image_uri" id="image_uri" value="<?php print esc_attr( $custom_logo_url ); ?>" />
 				<input type="hidden" name="redirect_uri" id="redirect_uri" value="<?php print esc_attr( $redirect_uri ); ?>" />
-				<input type="submit" id="hello_quickstart" class="hello-btn" value="ō&nbsp;&nbsp;&nbsp;Continue with Hellō Quickstart" />
+				<input type="submit" id="hello_quickstart" class="hello-btn" value="ō&nbsp;&nbsp;&nbsp;Configure your site with Hellō Quickstart" />
 			</form>
 
 			<?php } ?>

--- a/includes/hello-login-settings-page.php
+++ b/includes/hello-login-settings-page.php
@@ -231,6 +231,15 @@ class Hello_Login_Settings_Page {
 				case 'quickstart_missing_client_id':
 					add_action( 'admin_notices', array( $this, 'admin_notice_quickstart_missing_client_id' ) );
 					break;
+				case 'unlink_success':
+					add_action( 'admin_notices', array( $this, 'admin_notice_unlink_success' ) );
+					break;
+				case 'unlink_no_session':
+					add_action( 'admin_notices', array( $this, 'admin_notice_unlink_no_session' ) );
+					break;
+				case 'unlink_not_linked':
+					add_action( 'admin_notices', array( $this, 'admin_notice_unlink_not_linked' ) );
+					break;
 				default:
 					$this->logger->log( 'Unknown message id: ' . $message_id, 'admin_notices' );
 					add_action( 'admin_notices', array( $this, 'admin_notice_quickstart_unknown' ) );
@@ -247,7 +256,7 @@ class Hello_Login_Settings_Page {
 		$site_name = get_bloginfo( 'name' );
 		?>
 		<div class="notice notice-success is-dismissible">
-			<p><?php esc_html_e( "Quickstart has successfully registered your site \"$site_name\" at Hellō!", 'hello-login' ); ?></p>
+			<p><?php esc_html_e( "Quickstart has successfully registered your site \"$site_name\" at Hellō", 'hello-login' ); ?></p>
 		</div>
 		<?php
 	}
@@ -260,7 +269,7 @@ class Hello_Login_Settings_Page {
 	public function admin_notice_quickstart_existing_client_id() {
 		?>
 		<div class="notice notice-error is-dismissible">
-			<p><?php esc_html_e( 'Quickstart failed: client id already set!', 'hello-login' ); ?></p>
+			<p><?php esc_html_e( 'Quickstart failed: client id already set', 'hello-login' ); ?></p>
 		</div>
 		<?php
 	}
@@ -273,7 +282,7 @@ class Hello_Login_Settings_Page {
 	public function admin_notice_quickstart_missing_client_id() {
 		?>
 		<div class="notice notice-error is-dismissible">
-			<p><?php esc_html_e( 'Quickstart failed: no client id was sent!', 'hello-login' ); ?></p>
+			<p><?php esc_html_e( 'Quickstart failed: no client id was sent', 'hello-login' ); ?></p>
 		</div>
 		<?php
 	}
@@ -286,7 +295,46 @@ class Hello_Login_Settings_Page {
 	public function admin_notice_quickstart_unknown() {
 		?>
 		<div class="notice notice-error is-dismissible">
-			<p><?php esc_html_e( 'Quickstart failed: unknown!', 'hello-login' ); ?></p>
+			<p><?php esc_html_e( 'Quickstart failed: unknown', 'hello-login' ); ?></p>
+		</div>
+		<?php
+	}
+
+	/**
+	 * Show admin notice for successful unlink.
+	 *
+	 * @return void
+	 */
+	public function admin_notice_unlink_success() {
+		?>
+		<div class="notice notice-success is-dismissible">
+			<p><?php esc_html_e( "This account has been unlinked with Hellō", 'hello-login' ); ?></p>
+		</div>
+		<?php
+	}
+
+	/**
+	 * Show admin notice for failed unlink because no current user was found.
+	 *
+	 * @return void
+	 */
+	public function admin_notice_unlink_no_session() {
+		?>
+		<div class="notice notice-error is-dismissible">
+			<p><?php esc_html_e( 'Unlink failed: no current user was found', 'hello-login' ); ?></p>
+		</div>
+		<?php
+	}
+
+	/**
+	 * Show admin notice for failed unlink because current user is not linked.
+	 *
+	 * @return void
+	 */
+	public function admin_notice_unlink_not_linked() {
+		?>
+		<div class="notice notice-error is-dismissible">
+			<p><?php esc_html_e( 'Unlink failed: current user not linked', 'hello-login' ); ?></p>
 		</div>
 		<?php
 	}

--- a/includes/hello-login-settings-page.php
+++ b/includes/hello-login-settings-page.php
@@ -219,7 +219,7 @@ class Hello_Login_Settings_Page {
 
 	private function add_admin_notices() {
 		if ( isset( $_GET['hello-login-msg'] ) && ! empty( $_GET['hello-login-msg'] ) ) {
-			$message_id = $_GET['hello-login-msg'];
+			$message_id = sanitize_text_field( $_GET['hello-login-msg'] );
 
 			switch ($message_id) {
 				case 'quickstart_success':
@@ -554,7 +554,7 @@ class Hello_Login_Settings_Page {
 		wp_enqueue_style( 'hello-login-admin', plugin_dir_url( __DIR__ ) . 'css/styles-admin.css', array(), Hello_Login::VERSION, 'all' );
 
 		$redirect_uri = site_url( '?hello-login=callback' );
-		$quickstart_uri = rest_url( 'hello-login/v1/quickstart' );
+		$quickstart_uri = site_url( '?hello-login=quickstart' );
 
 		$custom_logo_url = '';
 		if ( has_custom_logo() ) {

--- a/includes/hello-login-settings-page.php
+++ b/includes/hello-login-settings-page.php
@@ -240,6 +240,9 @@ class Hello_Login_Settings_Page {
 				case 'unlink_not_linked':
 					add_action( 'admin_notices', array( $this, 'admin_notice_unlink_not_linked' ) );
 					break;
+				case 'link_success':
+					add_action( 'admin_notices', array( $this, 'admin_notice_link_success' ) );
+					break;
 				default:
 					$this->logger->log( 'Unknown message id: ' . $message_id, 'admin_notices' );
 					add_action( 'admin_notices', array( $this, 'admin_notice_quickstart_unknown' ) );
@@ -335,6 +338,19 @@ class Hello_Login_Settings_Page {
 		?>
 		<div class="notice notice-error is-dismissible">
 			<p><?php esc_html_e( 'Unlink failed: current user not linked', 'hello-login' ); ?></p>
+		</div>
+		<?php
+	}
+
+	/**
+	 * Show admin notice for successful link.
+	 *
+	 * @return void
+	 */
+	public function admin_notice_link_success() {
+		?>
+		<div class="notice notice-success is-dismissible">
+			<p><?php esc_html_e( "This account has been linked with Hellō", 'hello-login' ); ?></p>
 		</div>
 		<?php
 	}

--- a/includes/hello-login-settings-page.php
+++ b/includes/hello-login-settings-page.php
@@ -638,19 +638,6 @@ class Hello_Login_Settings_Page {
 			<?php if ( ! $configured ) { ?>
 			<h2>To use Hellō, you must configure your site. Hellō Quickstart will get you up and running in seconds. You will create a Hellō Wallet if you don't have one already.</h2>
 
-			<p>The following information is sent with the Quickstart request:
-				<ul style="list-style-type:disc; padding-left: 3em">
-					<li>Site Name: <strong><?php print esc_html( get_bloginfo( 'name' ) ); ?></strong></li>
-					<?php if ( $custom_logo_url ) { ?>
-					<li>Site Logo: <img src="<?php print esc_attr( $custom_logo_url ); ?>" alt="Site Logo" height="70" /></li>
-					<?php } ?>
-					<?php if ( get_privacy_policy_url() ) { ?>
-					<li>Privacy Policy URL: <code><?php print esc_html( get_privacy_policy_url() ); ?></code></li>
-					<?php } ?>
-					<li>Redirect URI: <code><?php print esc_html( $redirect_uri ); ?></code></li>
-				</ul>
-			</p>
-
 			<form method="get" action="https://quickstart.hello.coop/">
 				<input type="hidden" name="integration" id="integration" value="wordpress" />
 				<input type="hidden" name="response_uri" id="response_uri" value="<?php print esc_attr( $quickstart_uri ); ?>" />

--- a/includes/hello-login-settings-page.php
+++ b/includes/hello-login-settings-page.php
@@ -213,6 +213,81 @@ class Hello_Login_Settings_Page {
 				$field
 			);
 		}
+
+		$this->add_admin_notices();
+	}
+
+	private function add_admin_notices() {
+		if ( isset( $_GET['hello-login-msg'] ) && ! empty( $_GET['hello-login-msg'] ) ) {
+			$message_id = $_GET['hello-login-msg'];
+
+			switch ($message_id) {
+				case 'quickstart_success':
+					add_action( 'admin_notices', array( $this, 'admin_notice_quickstart_success' ) );
+					break;
+				case 'quickstart_existing_client_id':
+					add_action( 'admin_notices', array( $this, 'admin_notice_quickstart_existing_client_id' ) );
+					break;
+				case 'quickstart_missing_client_id':
+					add_action( 'admin_notices', array( $this, 'admin_notice_quickstart_missing_client_id' ) );
+					break;
+				default:
+					$this->logger->log( 'Unknown message id: ' . $message_id, 'admin_notices' );
+					add_action( 'admin_notices', array( $this, 'admin_notice_quickstart_unknown' ) );
+			}
+		}
+	}
+
+	/**
+	 * Show admin notice for successful Quickstart.
+	 *
+	 * @return void
+	 */
+	public function admin_notice_quickstart_success() {
+		?>
+		<div class="notice notice-success is-dismissible">
+			<p><?php esc_html_e( 'Quickstart succeeded!', 'hello-login' ); ?></p>
+		</div>
+		<?php
+	}
+
+	/**
+	 * Show admin notice for failed Quickstart because the client id is already set.
+	 *
+	 * @return void
+	 */
+	public function admin_notice_quickstart_existing_client_id() {
+		?>
+		<div class="notice notice-error is-dismissible">
+			<p><?php esc_html_e( 'Quickstart failed: client id already set!', 'hello-login' ); ?></p>
+		</div>
+		<?php
+	}
+
+	/**
+	 * Show admin notice for failed Quickstart because the client id is missing.
+	 *
+	 * @return void
+	 */
+	public function admin_notice_quickstart_missing_client_id() {
+		?>
+		<div class="notice notice-error is-dismissible">
+			<p><?php esc_html_e( 'Quickstart failed: no client id was sent!', 'hello-login' ); ?></p>
+		</div>
+		<?php
+	}
+
+	/**
+	 * Show admin notice for failed Quickstart, unknown message id.
+	 *
+	 * @return void
+	 */
+	public function admin_notice_quickstart_unknown() {
+		?>
+		<div class="notice notice-error is-dismissible">
+			<p><?php esc_html_e( 'Quickstart failed: unknown!', 'hello-login' ); ?></p>
+		</div>
+		<?php
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -13,14 +13,14 @@ Free and simple to setup plugin provides registration and login with the Hellō 
 
 == Description ==
 
-Provide your users a registration and login using their choice of popular social login, email, or even a crypto wallet. No need for you to configure your application at each provider or pay for a premium plugin.
+Provide your users registration and login using their choice of popular social login, email, or phone. No need for you to configure your application at each provider or pay for a premium plugin.
 
 Hellō Login verifies your users' email addresses so you don't have to. No longer do they have to manage another username and password to use your site.
 
 Hellō is a cloud identity wallet cooperatively operated with a mission to empower users to control their identity. Learn more at [hello.coop](https://www.hello.coop/).
 
-* Hellō Login installs with Hellō Quickstart to get you up and running in seconds.
-* Users control their identity with their Hellō Wallet. No need for you to manage how they login.
+* Hellō Login installs with Hellō Quickstart to get you up and running in 7 clicks.
+* Users manage how they login at [wallet.hello.coop](https://wallet.hello.coop). No need for you to manage how they login or help them recover their account.
 * Hellō Login is free for users and early adopting sites. See [hello.coop](https://www.hello.coop/) for details.
 
 Documentation, configuration, and settings can be found in Settings >  Hellō Login


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [plugin Contributing guideline](https://github.com/oidc-wp/openid-connect-generi/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

* added admin notices for the following actions, both success and errors:
  * Quickstart
  * link account
  * unlink account
* Quickstart moved from REST API to regular endpoint
* copy updates on settings page and readme
* settings shown only if admin account linked
  * "Not Now" link added to bypass linking
  * "Not Now" decision saved to settings
* moved profile hook to main plugin class
* profile hook called only if plugin is configured
* implemented unlink when editing other users


Closes #69 .
Closes #56 .
Closes #52 .

![image](https://user-images.githubusercontent.com/942078/207723563-715999d9-cd72-48e3-b62a-4a97e697089d.png)
