### PR TITLE
Fix autoloading

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -67,15 +67,7 @@
 	},
 	"autoload": {
 		"classmap": [
-			"hello-login.php",
-			"includes/hello-login-client.php",
-			"includes/hello-login-client-wrapper.php",
-			"includes/hello-login-login-form.php",
-			"includes/hello-login-option-logger.php",
-			"includes/hello-login-option-settings.php",
-			"includes/hello-login-settings-page.php",
-			"includes/hello-login-util.php",
-			"includes/Hello_Login_Invites.php"
+			"includes/"
 		]
 	},
 	"scripts": {


### PR DESCRIPTION
The main file is loaded by WordPress core.
I hope files in `includes/` are clean class files without side-effects.