### PR TITLE
Button styling fixes

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -15,7 +15,7 @@
  */
 function hello_login_enqueue_scripts_and_styles() {
 	wp_enqueue_script( 'hello-button', 'https://cdn.hello.coop/js/hello-btn.js', array(), Hello_Login::VERSION );
-	wp_enqueue_style( 'hello-button', 'https://cdn.hello.coop/css/hello-btn.css', array(), Hello_Login::VERSION, 'all' );
+	wp_enqueue_style( 'hello-button', 'https://cdn.hello.coop/css/hello-btn-wp.css', array(), Hello_Login::VERSION, 'all' );
 	wp_enqueue_style( 'hello-login-hello-button', plugin_dir_url( __DIR__ ) . 'css/styles.css', array(), Hello_Login::VERSION, 'all' );
 }
 

--- a/includes/hello-login-login-form.php
+++ b/includes/hello-login-login-form.php
@@ -261,7 +261,7 @@ class Hello_Login_Login_Form {
 		?>
 		<div class="hello-container" style="display: block; text-align: <?php print esc_html( $atts['align'] ); ?>;">
 			<button type="button" class="hello-btn" onclick="parent.location='<?php print esc_js( $start_url ); ?>'" data-label="<?php print esc_html( 'ō&nbsp;&nbsp;&nbsp;' . $atts['label'] ); ?>"></button>
-			<?php if ( $atts['show_hint'] ) { ?><button class="hello-about" style="text-align: <?php print esc_html( $atts['align'] ); ?>;"></button><?php } ?>
+			<?php if ( $atts['show_hint'] ) { ?><button type="button" class="hello-about"  style="text-align: <?php print esc_html( $atts['align'] ); ?>;"></button><?php } ?>
 		</div>
 		<?php
 


### PR DESCRIPTION
1. Update to using wordpress specific Hellō CSS stylesheet
2. Add type="button" attribute to .hello-about (tooltip) button (bug where clicking on the tooltip button triggered a form submit)